### PR TITLE
Stop execution of install script on errors

### DIFF
--- a/deps.mk
+++ b/deps.mk
@@ -18,11 +18,11 @@ vpath ckanext-% $(root_dir)
 vpath ckan $(root_dir)
 
 define pip-file
-$(if $(pyright_compatible),SETUPTOOLS_ENABLE_FEATURES="legacy-editable" )pip install $(if $(2),-U )-r "$(1)"$(if $(local), --no-index -f "$(root_dir)/$(index)") $(if $(constraints),-c $(constraints));
+$(if $(pyright_compatible),SETUPTOOLS_ENABLE_FEATURES="legacy-editable" )pip install $(if $(2),-U )-r "$(1)"$(if $(local), --no-index -f "$(root_dir)/$(index)") $(if $(constraints),-c $(constraints)) || exit 1;
 endef
 
 define self-install
-$(if $(pyright_compatible),SETUPTOOLS_ENABLE_FEATURES="legacy-editable" )pip install -e'.$(if $(1),[$(1)])' $(if $(local), --no-index -f "$(root_dir)/$(index)") $(if $(constraints),-c $(constraints));
+$(if $(pyright_compatible),SETUPTOOLS_ENABLE_FEATURES="legacy-editable" )pip install -e'.$(if $(1),[$(1)])' $(if $(local), --no-index -f "$(root_dir)/$(index)") $(if $(constraints),-c $(constraints)) || exit 1;
 endef
 
 define resolve-package-extras


### PR DESCRIPTION
### The problem

When running `make install` (or one of the targets that calls it like `make full-upgrade`) the script creates sub-targets for each of the extensions defined in `ext_list` (e.g. `install-spatial`,  `install-saml`, `install-syndicate`, etc). All these sub-targets 
will be called in succession, but if there is an error on one of them, the script will jump to the next one without stopping (e.g if saml` failed, will continue installing syndicate and output the normal install messages).

This is problematic as it leaves a broken environment without proper feedback to the user, and is specially bad in deployment scripts or Docker images as it will report a successful build when it is actually broken.

### The solution

I have very limited experience with Makefiles but it looked like the issue was that the functions defined were not propagating the error codes properly to the sub-targets. I modified the more basal ones as they are called by all the other functions and targets but I might have missed some.