### PR TITLE
Hide credentials from git clone output

### DIFF
--- a/deps.mk
+++ b/deps.mk
@@ -160,7 +160,8 @@ install-ckan:
 
 ckanext-%:
 	@echo [Clone $* into $(ext_path)]
-	git clone $(remote) $(ext_path);
+	@echo "Running: git clone $(shell echo '$(remote)' | sed 's|://[^@]*@|://*****:*****@|') $(ext_path)"
+	@git clone $(remote) $(ext_path);
 	cd $(ext_path); \
 	$(call checkout-target,$(target),$(type))
 
@@ -181,7 +182,8 @@ ckan ckan-sync: remote = $(firstword $(call resolve-remote,ckan))
 ckan ckan-sync ckan-check: target = $(lastword $(call resolve-remote,ckan))
 ckan:
 	@echo [Clone ckan into $(ckan_path)]
-	git clone $(remote) $(ckan_path);
+	@echo "Running: git clone $(shell echo '$(remote)' | sed 's|://[^@]*@|://*****:*****@|') $(ext_path)"
+	@git clone $(remote) $(ext_path);
 
 ckan-sync: ckan
 	$(call ensure-ckan)


### PR DESCRIPTION
Sometimes you need to use https remotes that include user name and password (e.g. to clone private repos in CI/CD). `git clone` will output the whole remote by default so we hide its output and echo a sanitized version if the remote contains credentials.


So instead of this:

```
[Clone mbie-erm-theme into ../ckanext-mbie-erm-theme]                                                                                                                                                                                              
git clone https://secret_user:secret_password@bitbucket.org/link-digital-development/ckanext-mbie-erm-theme.git ../ckanext-mbie-erm-theme
Cloning into '../ckanext-mbie-erm-theme'...
```

We get this:
```
[Clone mbie-erm-theme into ../ckanext-mbie-erm-theme]
Running: git clone https://*****:*****@bitbucket.org/link-digital-development/ckanext-mbie-erm-theme.git ../ckanext-mbie-erm-theme
Cloning into '../ckanext-mbie-erm-theme'...
```
